### PR TITLE
Add missing import statement

### DIFF
--- a/src/notifier.py
+++ b/src/notifier.py
@@ -5,6 +5,7 @@ import json
 import boto3
 import time
 import logging
+import os
 
 from pprint import pprint
 


### PR DESCRIPTION
The previous deploy failed execution with the following:

```python
[ERROR] NameError: name 'os' is not defined
Traceback (most recent call last):
  File "/var/lang/lib/python3.7/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/notifier.py", line 18, in <module>
    LOGLEVEL = os.environ.get('LOGLEVEL', 'WARNING').upper()
```